### PR TITLE
fix issue with invalid JSON in Monobank\Exception\Factory

### DIFF
--- a/src/Monobank/Exception/Factory.php
+++ b/src/Monobank/Exception/Factory.php
@@ -18,7 +18,7 @@ final class Factory
 
     public static function createFromResponse(ResponseInterface $response)
     {
-        $errorDescription = json_decode($response->getBody()->getContents(), true)['errorDescription'];
+        $errorDescription = json_decode($response->getBody()->getContents(), true)['errorDescription'] ?? 'Unknown error';
 
         switch ($errorDescription) {
             case self::INVALID_ACCOUNT:


### PR DESCRIPTION
Hi. This morning I caught a fatal, I think that the monobank response concontained an invalid JSON.
PHP Fatal error:  Uncaught Error: Wrong parameters for Monobank\Exception\MonobankException([string $message [, long $code [, Throwable $previous = NULL]]]) in .../vendor/iillexial/php-monobank-api/src/Monobank/Exception/Factory.php:33